### PR TITLE
Correct process for GET request

### DIFF
--- a/src/TogglService.php
+++ b/src/TogglService.php
@@ -89,9 +89,8 @@ class TogglService extends BaseService
         }
         $this->uri = 'https://toggl.com/reports/api/v2/details?user_agent=' . $this->user_agent . '&since=' . $startdate . '&until=' . $enddate . '&workspace_id=' . $this->workspace_id;
 
-        $data = [];
-        $data = json_encode($data);
-
+        $data = null;
+        
         $response = $this->processRequest($data, self::GET);
         $this->_handleError($data, $response);
         $toggl_entries = $this->processTogglResponse($response);


### PR DESCRIPTION
Having `$data` content tries to set a Content-Length on a GET request, which returns HTTP Bad Request (400). Setting this to null initiates a proper request.